### PR TITLE
Extend listable instruments

### DIFF
--- a/ui/src/pages/listing/New.tsx
+++ b/ui/src/pages/listing/New.tsx
@@ -1,22 +1,25 @@
 // Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import classnames from "classnames";
-import { useLedger, useParty, useStreamQueries } from "@daml/react";
-import { Typography, Grid, Paper, Select, MenuItem, TextField, Button, MenuProps, FormControl, InputLabel, IconButton, Box } from "@mui/material";
-import useStyles from "../styles";
-import { claimToNode } from "../../components/Claims/util";
-import { Visibility } from "@mui/icons-material";
-import { Service } from "@daml.js/daml-finance-app/lib/Daml/Finance/App/Listing/Service";
 import { Service as AutoService } from "@daml.js/daml-finance-app/lib/Daml/Finance/App/Listing/Auto/Service";
-import { Spinner } from "../../components/Spinner/Spinner";
-import { ClaimsTreeBuilder, ClaimTreeNode } from "../../components/Claims/ClaimsTreeBuilder";
-import { Instrument as Derivative } from "@daml.js/daml-finance-derivative/lib/Daml/Finance/Derivative/Instrument";
+import { Service } from "@daml.js/daml-finance-app/lib/Daml/Finance/App/Listing/Service";
 import { Instrument } from "@daml.js/daml-finance-asset/lib/Daml/Finance/Asset/Instrument";
-import { createKeyBase, createKeyDerivative, createSet } from "../../util";
+import { FixedRateBond } from "@daml.js/daml-finance-bond/lib/Daml/Finance/Bond/FixedRate";
+import { FloatingRateBond } from "@daml.js/daml-finance-bond/lib/Daml/Finance/Bond/FloatingRate";
+import { InflationLinkedBond } from "@daml.js/daml-finance-bond/lib/Daml/Finance/Bond/InflationLinked";
+import { ZeroCouponBond } from "@daml.js/daml-finance-bond/lib/Daml/Finance/Bond/ZeroCoupon";
+import { Instrument as Derivative } from "@daml.js/daml-finance-derivative/lib/Daml/Finance/Derivative/Instrument";
+import { useLedger, useParty, useStreamQueries } from "@daml/react";
+import { Visibility } from "@mui/icons-material";
+import { Box, Button, FormControl, Grid, IconButton, InputLabel, MenuItem, MenuProps, Paper, Select, TextField, Typography } from "@mui/material";
+import classnames from "classnames";
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ClaimTreeNode } from "../../components/Claims/ClaimsTreeBuilder";
+import { Spinner } from "../../components/Spinner/Spinner";
 import { useParties } from "../../context/PartiesContext";
+import { createInstrumentKey, createSet } from "../../util";
+import useStyles from "../styles";
 
 export const New : React.FC = () => {
   const classes = useStyles();
@@ -36,27 +39,47 @@ export const New : React.FC = () => {
   const { contracts: autoServices, loading: l2 } = useStreamQueries(AutoService);
   const { contracts: instruments, loading: l3 } = useStreamQueries(Instrument);
   const { contracts: derivatives, loading: l4 } = useStreamQueries(Derivative);
+  const { contracts: fixedRateBonds, loading: l5 } = useStreamQueries(FixedRateBond);
+  const { contracts: floatingRateBonds, loading: l6 } = useStreamQueries(FloatingRateBond);
+  const { contracts: inflationLinkedBonds, loading: l7 } = useStreamQueries(InflationLinkedBond);
+  const { contracts: zeroCouponBonds, loading: l8 } = useStreamQueries(ZeroCouponBond);
 
   const myServices = services.filter(s => s.payload.customer === party);
   const myAutoServices = autoServices.filter(s => s.payload.customer === party);
-  const tradedInstrument = derivatives.find(c => c.payload.id.label === tradedInstrumentLabel);
+
+  const tradableInstruments =
+    derivatives.map(createInstrumentKey)
+      .concat(
+        fixedRateBonds.map(createInstrumentKey)
+      )
+      .concat(
+        floatingRateBonds.map(createInstrumentKey)
+      )
+      .concat(
+        inflationLinkedBonds.map(createInstrumentKey)
+      )
+      .concat(
+        zeroCouponBonds.map(createInstrumentKey)
+      )
+
+  const tradedInstrument = tradableInstruments.find(k => k.id.label === tradedInstrumentLabel);
   const quotedInstrument = instruments.find(c => c.payload.id.label === quotedInstrumentLabel);
 
   const canRequest = !!tradedInstrumentLabel && !!tradedInstrument && !!quotedInstrumentLabel && !!quotedInstrument && !!id;
 
-  useEffect(() => {
-    if (!!tradedInstrument) setNode(claimToNode(tradedInstrument.payload.claims));
-  }, [tradedInstrument]);
+  // useEffect(() => {
+  //   if (!!tradedInstrument) setNode(claimToNode(tradedInstrument.payload.claims));
+  // }, [tradedInstrument]);
 
-  if (l1 || l2 || l3 || l4) return (<Spinner />);
+  if (l1 || l2 || l3 || l4 || l5 || l6 || l7 || l8) return (<Spinner />);
   if (myServices.length === 0) return (<div style={{display: 'flex', justifyContent: 'center', marginTop: 350 }}><h1>No listing service found for customer: {party}</h1></div>);
 
   const requestListing = async () => {
     if (!tradedInstrument || !quotedInstrument) return;
     const arg = {
       id,
-      tradedInstrument: createKeyDerivative(tradedInstrument),
-      quotedInstrument: createKeyBase(quotedInstrument),
+      tradedInstrument: tradedInstrument,
+      quotedInstrument: createInstrumentKey(quotedInstrument),
       observers : createSet([ getParty("Public") ])
     };
     if (myAutoServices.length > 0) {
@@ -85,7 +108,7 @@ export const New : React.FC = () => {
                     <Box className={classes.fullWidth}>
                       <InputLabel className={classes.selectLabel}>Traded Asset</InputLabel>
                       <Select variant="standard" className={classes.width90} value={tradedInstrumentLabel} onChange={e => setTradedAssetLabel(e.target.value as string)} MenuProps={menuProps}>
-                        {derivatives.filter(c => c.payload.id.label !== quotedInstrumentLabel).map((c, i) => (<MenuItem key={i} value={c.payload.id.label}>{c.payload.id.label}</MenuItem>))}
+                        {tradableInstruments.filter(c => c.id.label !== quotedInstrumentLabel).map((c, i) => (<MenuItem key={i} value={c.id.label}>{c.id.label}</MenuItem>))}
                       </Select>
                       <IconButton className={classes.marginLeft10} color="primary" size="small" component="span" onClick={() => setShowTradedAsset(!showTradedInstrument)}>
                         <Visibility fontSize="small"/>
@@ -112,7 +135,7 @@ export const New : React.FC = () => {
                 <Grid item xs={12}>
                   <Paper className={classnames(classes.fullWidth, classes.paper)}>
                     <Typography variant="h5" className={classes.heading}>Traded Asset</Typography>
-                    <ClaimsTreeBuilder node={node} setNode={setNode} assets={[]}/>
+                    {/* <ClaimsTreeBuilder node={node} setNode={setNode} assets={[]}/> */}
                   </Paper>
                 </Grid>)}
             </Grid>

--- a/ui/src/pages/listing/New.tsx
+++ b/ui/src/pages/listing/New.tsx
@@ -10,12 +10,10 @@ import { InflationLinkedBond } from "@daml.js/daml-finance-bond/lib/Daml/Finance
 import { ZeroCouponBond } from "@daml.js/daml-finance-bond/lib/Daml/Finance/Bond/ZeroCoupon";
 import { Instrument as Derivative } from "@daml.js/daml-finance-derivative/lib/Daml/Finance/Derivative/Instrument";
 import { useLedger, useParty, useStreamQueries } from "@daml/react";
-import { Visibility } from "@mui/icons-material";
-import { Box, Button, FormControl, Grid, IconButton, InputLabel, MenuItem, MenuProps, Paper, Select, TextField, Typography } from "@mui/material";
+import { Box, Button, FormControl, Grid, InputLabel, MenuItem, MenuProps, Paper, Select, TextField, Typography } from "@mui/material";
 import classnames from "classnames";
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { ClaimTreeNode } from "../../components/Claims/ClaimsTreeBuilder";
 import { Spinner } from "../../components/Spinner/Spinner";
 import { useParties } from "../../context/PartiesContext";
 import { createInstrumentKey, createSet } from "../../util";
@@ -28,9 +26,6 @@ export const New : React.FC = () => {
   const [ tradedInstrumentLabel, setTradedAssetLabel ] = useState("");
   const [ quotedInstrumentLabel, setQuotedAssetLabel ] = useState("");
   const [ id, setId ] = useState("");
-
-  const [ showTradedInstrument, setShowTradedAsset ] = useState(false);
-  const [ node, setNode ] = useState<ClaimTreeNode | undefined>();
 
   const { getParty } = useParties();
   const ledger = useLedger();
@@ -66,10 +61,6 @@ export const New : React.FC = () => {
   const quotedInstrument = instruments.find(c => c.payload.id.label === quotedInstrumentLabel);
 
   const canRequest = !!tradedInstrumentLabel && !!tradedInstrument && !!quotedInstrumentLabel && !!quotedInstrument && !!id;
-
-  // useEffect(() => {
-  //   if (!!tradedInstrument) setNode(claimToNode(tradedInstrument.payload.claims));
-  // }, [tradedInstrument]);
 
   if (l1 || l2 || l3 || l4 || l5 || l6 || l7 || l8) return (<Spinner />);
   if (myServices.length === 0) return (<div style={{display: 'flex', justifyContent: 'center', marginTop: 350 }}><h1>No listing service found for customer: {party}</h1></div>);
@@ -110,9 +101,6 @@ export const New : React.FC = () => {
                       <Select variant="standard" className={classes.width90} value={tradedInstrumentLabel} onChange={e => setTradedAssetLabel(e.target.value as string)} MenuProps={menuProps}>
                         {tradableInstruments.filter(c => c.id.label !== quotedInstrumentLabel).map((c, i) => (<MenuItem key={i} value={c.id.label}>{c.id.label}</MenuItem>))}
                       </Select>
-                      <IconButton className={classes.marginLeft10} color="primary" size="small" component="span" onClick={() => setShowTradedAsset(!showTradedInstrument)}>
-                        <Visibility fontSize="small"/>
-                      </IconButton>
                     </Box>
                   </FormControl>
                   <FormControl className={classes.inputField} fullWidth>
@@ -127,17 +115,6 @@ export const New : React.FC = () => {
                   <Button className={classnames(classes.fullWidth, classes.buttonMargin)} size="large" variant="contained" color="primary" disabled={!canRequest} onClick={requestListing}>Request Listing</Button>
                 </Paper>
               </Grid>
-            </Grid>
-          </Grid>
-          <Grid item xs={8}>
-            <Grid container direction="column" spacing={2}>
-              {showTradedInstrument && (
-                <Grid item xs={12}>
-                  <Paper className={classnames(classes.fullWidth, classes.paper)}>
-                    <Typography variant="h5" className={classes.heading}>Traded Asset</Typography>
-                    {/* <ClaimsTreeBuilder node={node} setNode={setNode} assets={[]}/> */}
-                  </Paper>
-                </Grid>)}
             </Grid>
           </Grid>
         </Grid>

--- a/ui/src/util.ts
+++ b/ui/src/util.ts
@@ -1,12 +1,11 @@
 // Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Set } from "@daml.js/97b883cd8a2b7f49f90d5d39c981cf6e110cf1f1c64427a28a6d58ec88c43657/lib/DA/Set/Types"
+import { Set } from "@daml.js/97b883cd8a2b7f49f90d5d39c981cf6e110cf1f1c64427a28a6d58ec88c43657/lib/DA/Set/Types";
 import { Fungible } from "@daml.js/daml-finance-asset/lib/Daml/Finance/Asset/Fungible";
 import { Instrument as Base } from "@daml.js/daml-finance-asset/lib/Daml/Finance/Asset/Instrument";
 import { Instrument as Derivative } from "@daml.js/daml-finance-derivative/lib/Daml/Finance/Derivative/Instrument";
-import { InstrumentKey } from "@daml.js/daml-finance-interface-asset/lib/Daml/Finance/Interface/Asset/Types";
-import { Id } from "@daml.js/daml-finance-interface-asset/lib/Daml/Finance/Interface/Asset/Types";
+import { Id, InstrumentKey } from "@daml.js/daml-finance-interface-asset/lib/Daml/Finance/Interface/Asset/Types";
 import Ledger, { CreateEvent } from "@daml/ledger";
 import { ContractId, emptyMap } from "@daml/types";
 
@@ -64,6 +63,11 @@ export const createKeyDerivative = (c : CreateEvent<Derivative>) : InstrumentKey
 };
 
 export const createKeyBase = (c : CreateEvent<Base>) : InstrumentKey => {
+  return { depository: c.payload.depository, issuer: c.payload.issuer, id: c.payload.id };
+};
+
+// TODO replace any with base instrument interface once interface subscriptions are available
+export const createInstrumentKey = (c : CreateEvent<any>) : InstrumentKey => {
   return { depository: c.payload.depository, issuer: c.payload.issuer, id: c.payload.id };
 };
 


### PR DESCRIPTION
This will become easier once interface subscriptions are available. For now I take all derivatives and bonds.

I had to remove the tree viewer from the listing page, as in a generic setting we could by listing anything. Let me know if it breaks the narrative of the demo and I will add it back.