### PR TITLE
Fix holding choice for settlement

### DIFF
--- a/ui/src/pages/settlement/Batch.tsx
+++ b/ui/src/pages/settlement/Batch.tsx
@@ -42,7 +42,7 @@ export const Batch : React.FC = () => {
       const allocation : Allocation = { tag: "CreditReceiver", value: {} };
       await ledger.exercise(Instruction.Allocate, c.contractId, { actors, allocation });
     } else {
-      const holdingCid = await getFungible(party, c.payload.routedStep.quantity.amount, c.payload.routedStep.quantity.unit);
+      const holdingCid = await getFungible(party, c.payload.routedStep.quantity.amount, c.payload.routedStep.quantity.unit, c.payload.routedStep.custodian);
       const allocation : Allocation = { tag: "Pledge", value: holdingCid as string as ContractId<Holding> };
       await ledger.exercise(Instruction.Allocate, c.contractId, { actors, allocation });
     };


### PR DESCRIPTION
Currently the wrong holding might be picked for settlement if the owner owns the same instrument at multiple custodians. 

This fixes it by
- adding an optional `custodian` argument to `getFungible`
- when picking a holding for settlement, make sure the `custodian` from the `Instruction` is used